### PR TITLE
Fix build for provided CFLAGS on new tools

### DIFF
--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -75,8 +75,8 @@ TESTS = tests
 endif
 
 if USE_ECMULT_STATIC_PRECOMPUTATION
-CPPFLAGS_FOR_BUILD +=-I$(top_srcdir)
-CFLAGS_FOR_BUILD += -Wall -Wextra -Wno-unused-function
+CPPFLAGS_FOR_BUILD =-I$(top_srcdir)
+CFLAGS_FOR_BUILD = -Wall -Wextra -Wno-unused-function
 
 gen_context_OBJECTS = gen_context.o
 gen_context_BIN = gen_context$(BUILD_EXEEXT)


### PR DESCRIPTION
Using GCC v8 and environmentally-provided CFLAGS+CPPFLAGS+CXXFLAGS variables breaks the build. This fix restores the order, works on older GCC v7 as well