### PR TITLE
Alternative fix secp256k1 build

### DIFF
--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -75,8 +75,8 @@ TESTS = tests
 endif
 
 if USE_ECMULT_STATIC_PRECOMPUTATION
-CPPFLAGS_FOR_BUILD +=-I$(top_srcdir)
-CFLAGS_FOR_BUILD += -Wall -Wextra -Wno-unused-function
+CPPFLAGS_FOR_BUILD =-I$(top_srcdir)
+CFLAGS_FOR_BUILD = -Wall -Wextra -Wno-unused-function
 
 gen_context_OBJECTS = gen_context.o
 gen_context_BIN = gen_context$(BUILD_EXEEXT)

--- a/src/secp256k1/autogen.sh
+++ b/src/secp256k1/autogen.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 set -e
+unset CFLAGS
+unset CPPFLAGS
+unset CXXFLAGS
 autoreconf -if --warnings=all


### PR DESCRIPTION
Also make sure your target OS does have `autoconf-archive` deb package installed! this package is not mandatory, but it helps to fix some more issues.